### PR TITLE
Avoid to preload all entities returned from a wdq request

### DIFF
--- a/src/TreeSimplifier/MissingObjectTripleNodeSimplifier.php
+++ b/src/TreeSimplifier/MissingObjectTripleNodeSimplifier.php
@@ -62,6 +62,7 @@ class MissingObjectTripleNodeSimplifier implements NodeSimplifier {
 	}
 
 	private function doSimplification(TripleNode $node) {
+		$this->loadEntitiesFromNode($node->getSubject());
 		$snaks = array();
 
 		foreach($node->getSubject() as $subject) {

--- a/src/TreeSimplifier/MissingSubjectTripleNodeSimplifier.php
+++ b/src/TreeSimplifier/MissingSubjectTripleNodeSimplifier.php
@@ -37,16 +37,10 @@ class MissingSubjectTripleNodeSimplifier implements NodeSimplifier {
 	private $simpleQueryService;
 
 	/**
-	 * @var WikibaseEntityProvider
-	 */
-	private $entityProvider;
-
-	/**
 	 * @param SimpleQueryService $simpleQueryService
 	 */
-	public function __construct(SimpleQueryService $simpleQueryService, WikibaseEntityProvider $entityProvider) {
+	public function __construct(SimpleQueryService $simpleQueryService) {
 		$this->simpleQueryService = $simpleQueryService;
-		$this->entityProvider = $entityProvider;
 	}
 
 	/**
@@ -81,8 +75,6 @@ class MissingSubjectTripleNodeSimplifier implements NodeSimplifier {
 				);
 			}
 		}
-
-		$this->entityProvider->loadEntities($queryResult);
 
 		return $this->formatQueryResult($queryResult);
 	}

--- a/src/TreeSimplifier/WikibaseNodeSimplifierFactory.php
+++ b/src/TreeSimplifier/WikibaseNodeSimplifierFactory.php
@@ -36,7 +36,7 @@ class WikibaseNodeSimplifierFactory extends NodeSimplifierFactory {
 			$this->newMeaninglessPredicateTripleNodeSimplifier($mediawikiApi, $cache, $languageCode),
 			$this->newTripleConverter($mediawikiApi, $cache, $languageCode),
 			$this->newMissingObjectTripleNodeSimplifier($mediawikiApi, $cache),
-			$this->newMissingSubjectTripleNodeSimplifier($wikidataQueryApi, $mediawikiApi, $cache)
+			$this->newMissingSubjectTripleNodeSimplifier($wikidataQueryApi)
 		));
 	}
 
@@ -52,11 +52,10 @@ class WikibaseNodeSimplifierFactory extends NodeSimplifierFactory {
 		return new MissingObjectTripleNodeSimplifier($this->newEntityProvider($mediawikiApi, $cache));
 	}
 
-	private function newMissingSubjectTripleNodeSimplifier(WikidataQueryApi $wikidataQueryApi, MediawikiApi $mediawikiApi, Cache $cache) {
+	private function newMissingSubjectTripleNodeSimplifier(WikidataQueryApi $wikidataQueryApi) {
 		$wikidataQueryFactory = new WikidataQueryFactory($wikidataQueryApi);
 		return new MissingSubjectTripleNodeSimplifier(
-			$wikidataQueryFactory->newSimpleQueryService(),
-			$this->newEntityProvider($mediawikiApi, $cache)
+			$wikidataQueryFactory->newSimpleQueryService()
 		);
 	}
 

--- a/tests/phpunit/TreeSimplifier/MissingSubjectTripleNodeSimplifierTest.php
+++ b/tests/phpunit/TreeSimplifier/MissingSubjectTripleNodeSimplifierTest.php
@@ -35,11 +35,8 @@ class MissingSubjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 		$queryServiceMock = $this->getMockBuilder('WikidataQueryApi\Services\SimpleQueryService')
 			->disableOriginalConstructor()
 			->getMock();
-		$entityProviderMock = $this->getMockBuilder('PPP\Wikidata\WikibaseEntityProvider')
-			->disableOriginalConstructor()
-			->getMock();
 
-		return new MissingSubjectTripleNodeSimplifier($queryServiceMock, $entityProviderMock);
+		return new MissingSubjectTripleNodeSimplifier($queryServiceMock);
 	}
 
 	public function simplifiableProvider() {
@@ -88,14 +85,7 @@ class MissingSubjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 			->with($this->equalTo($query))
 			->will($this->returnValue($queryResult));
 
-		$entityProviderMock = $this->getMockBuilder('PPP\Wikidata\WikibaseEntityProvider')
-			->disableOriginalConstructor()
-			->getMock();
-		$entityProviderMock->expects($this->any())
-			->method('loadEntities')
-			->with($this->equalTo($queryResult));
-
-		$simplifier = new MissingSubjectTripleNodeSimplifier($queryServiceMock, $entityProviderMock);
+		$simplifier = new MissingSubjectTripleNodeSimplifier($queryServiceMock);
 		$this->assertEquals(
 			$responseNodes,
 			$simplifier->simplify($queryNode)
@@ -208,11 +198,7 @@ class MissingSubjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 			->with($this->equalTo($query))
 			->will($this->returnValue($queryResult));
 
-		$entityProviderMock = $this->getMockBuilder('PPP\Wikidata\WikibaseEntityProvider')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$simplifier = new MissingSubjectTripleNodeSimplifier($queryServiceMock, $entityProviderMock);
+		$simplifier = new MissingSubjectTripleNodeSimplifier($queryServiceMock);
 
 		$this->setExpectedException('PPP\Module\TreeSimplifier\NodeSimplifierException');
 		$simplifier->simplify($queryNode);

--- a/tests/phpunit/TreeSimplifier/WikibaseTripleConverterTest.php
+++ b/tests/phpunit/TreeSimplifier/WikibaseTripleConverterTest.php
@@ -94,25 +94,6 @@ class WikibaseTripleConverterTest extends NodeSimplifierBaseTest {
 					new MissingNode()
 				)
 			),
-			array(
-				new TripleNode(
-					new MissingNode(),
-					new ResourceListNode(array(new StringResourceNode('birth name'))),
-					new MissingNode()
-				),
-				new UnionNode(array(
-					new TripleNode(
-						new MissingNode(),
-						new ResourceListNode(array(new WikibaseResourceNode('birth name', new EntityIdValue(new PropertyId('P1477'))))),
-						new MissingNode()
-					),
-					new TripleNode(
-						new MissingNode(),
-						new ResourceListNode(array(new WikibaseResourceNode('birth name', new EntityIdValue(new PropertyId('P513'))))),
-						new MissingNode()
-					),
-				))
-			),
 		);
 	}
 }


### PR DESCRIPTION
Such requests may return a huge number of results that may not be used in the following requests
