### PR TITLE
Stop using deprecated method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 	"prefer-stable": true,
 	"require": {
 		"php": ">=5.3.0",
+		"wikibase/data-model": "~2.5",
 		"addwiki/mediawiki-api-base": "~0.2",
 		"doctrine/cache": "~1.4",
 		"ppp/wikibase-entity-store": "*",

--- a/tests/phpunit/TreeSimplifier/MissingObjectTripleNodeSimplifierTest.php
+++ b/tests/phpunit/TreeSimplifier/MissingObjectTripleNodeSimplifierTest.php
@@ -110,7 +110,7 @@ class MissingObjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 		$list = array();
 
 		//Value
-		$douglasAdamItem = Item::newEmpty();
+		$douglasAdamItem = new Item();
 		$douglasAdamItem->setId(new ItemId('Q42'));
 		$birthPlaceStatement = new Statement(new Claim(
 			new PropertyValueSnak(new PropertyId('P214'), new StringValue('113230702'))
@@ -138,7 +138,7 @@ class MissingObjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 		);
 
 		//SomeValue
-		$douglasAdamItem = Item::newEmpty();
+		$douglasAdamItem = new Item();
 		$douglasAdamItem->setId(new ItemId('Q42'));
 		$birthPlaceStatement = new Statement(new Claim(new PropertySomeValueSnak(new PropertyId('P19'))));
 		$birthPlaceStatement->setGuid('42');
@@ -155,7 +155,7 @@ class MissingObjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 		);
 
 		//No result
-		$douglasAdamItem = Item::newEmpty();
+		$douglasAdamItem = new Item();
 		$douglasAdamItem->setId(new ItemId('Q42'));
 		$list[] = array(
 			new TripleNode(
@@ -169,7 +169,7 @@ class MissingObjectTripleNodeSimplifierTest extends NodeSimplifierBaseTest {
 		);
 
 		//Parsing
-		$douglasAdamItem = Item::newEmpty();
+		$douglasAdamItem = new Item();
 		$douglasAdamItem->setId(new ItemId('Q42'));
 		$list[] = array(
 			new TripleNode(

--- a/tests/phpunit/ValueFormatters/WikibaseEntityIdFormatterTest.php
+++ b/tests/phpunit/ValueFormatters/WikibaseEntityIdFormatterTest.php
@@ -81,7 +81,7 @@ class WikibaseEntityIdFormatterTest extends ValueFormatterTestBase {
 	}
 
 	private function getQ42() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setId( new ItemId('Q42'));
 		$item->getFingerprint()->setLabel('en', 'Douglas Adams');
 

--- a/tests/phpunit/ValueFormatters/WikibaseEntityIdJsonLdFormatterTest.php
+++ b/tests/phpunit/ValueFormatters/WikibaseEntityIdJsonLdFormatterTest.php
@@ -202,7 +202,7 @@ class WikibaseEntityIdJsonLdFormatterTest extends ValueFormatterTestBase {
 	}
 
 	private function getQ42() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setId( new ItemId('Q42'));
 		$item->getFingerprint()->setLabel('en', 'Douglas Adams');
 		$item->getFingerprint()->setDescription('en', 'Author');

--- a/tests/phpunit/ValueFormatters/WikibaseResourceNodeFormatterFactoryTest.php
+++ b/tests/phpunit/ValueFormatters/WikibaseResourceNodeFormatterFactoryTest.php
@@ -160,7 +160,7 @@ class WikibaseResourceNodeFormatterFactoryTest extends \PHPUnit_Framework_TestCa
 	}
 
 	private function getQ42() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setId( new ItemId('Q42'));
 		$item->getFingerprint()->setLabel('en', 'Douglas Adams');
 


### PR DESCRIPTION
Method was deprecated since Wikibase DataModel 2.5, which made the new notation possible.

Had to add Wikibase DataModel as dependency since it was not there already. Presumably this is also the case for other used components. Relying on transient dependencies is not safe. Created #95 to track this.